### PR TITLE
explicit connect packet access

### DIFF
--- a/src/v3/connect.rs
+++ b/src/v3/connect.rs
@@ -104,14 +104,6 @@ impl<Io> Connect<Io> {
     }
 }
 
-impl<Io> Deref for Connect<Io> {
-    type Target = mqtt::Connect;
-
-    fn deref(&self) -> &Self::Target {
-        &self.connect
-    }
-}
-
 impl<T> fmt::Debug for Connect<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.connect.fmt(f)

--- a/src/v3/connect.rs
+++ b/src/v3/connect.rs
@@ -34,6 +34,14 @@ impl<Io> Connect<Io> {
         }
     }
 
+    pub fn packet(&self) -> &mqtt::Connect {
+        &self.connect
+    }
+
+    pub fn packet_mut(&mut self) -> &mut mqtt::Connect {
+        &mut self.connect
+    }
+
     #[inline]
     pub fn io(&mut self) -> &mut Framed<Io, mqtt::Codec> {
         self.io.io()

--- a/src/v5/connect.rs
+++ b/src/v5/connect.rs
@@ -87,14 +87,6 @@ impl<Io> Connect<Io> {
     }
 }
 
-impl<Io> Deref for Connect<Io> {
-    type Target = codec::Connect;
-
-    fn deref(&self) -> &Self::Target {
-        &self.connect
-    }
-}
-
 impl<T> fmt::Debug for Connect<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.connect.fmt(f)

--- a/src/v5/connect.rs
+++ b/src/v5/connect.rs
@@ -36,6 +36,14 @@ impl<Io> Connect<Io> {
         }
     }
 
+    pub fn packet(&self) -> &codec::Connect {
+        &self.connect
+    }
+
+    pub fn packet_mut(&mut self) -> &mut codec::Connect {
+        &mut self.connect
+    }
+
     #[inline]
     pub fn io(&mut self) -> &mut Framed<Io, codec::Codec> {
         self.io.io()


### PR DESCRIPTION
- removes Deref impl for v3::Connect and v5::Connect
- introduces .packet() and .packet_mut() instead