### PR TITLE
sink: avoid accidental nested borrow_mut

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [0.7.0-b.4] - 2021-07-12
+
+* v3: avoid nested borrow_mut() calls in sink on puback mismatch
+
 ## [0.7.0-b.3] - 2021-07-04
 
 * Re-export ClientRouter, SubscribeBuilder, UnsubscribeBuilder

--- a/src/v3/shared.rs
+++ b/src/v3/shared.rs
@@ -33,7 +33,7 @@ impl Default for MqttSinkPool {
 
 pub(crate) struct MqttShared {
     pub(super) cap: Cell<usize>,
-    pub(super) queues: RefCell<MqttSharedQueues>,
+    queues: RefCell<MqttSharedQueues>,
     pub(super) inflight_idx: Cell<u16>,
     pub(super) pool: Rc<MqttSinkPool>,
     pub(super) state: State,
@@ -67,6 +67,11 @@ impl MqttShared {
         }
     }
 
+    pub(super) fn with_queues<R>(&self, f: impl FnOnce(&mut MqttSharedQueues) -> R) -> R {
+        let mut queues = self.queues.borrow_mut();
+        f(&mut queues)
+    }
+    
     pub(super) fn has_credit(&self) -> bool {
         self.cap.get() - self.queues.borrow().inflight.len() > 0
     }

--- a/src/v5/shared.rs
+++ b/src/v5/shared.rs
@@ -9,7 +9,7 @@ use crate::{error, io::State, types::packet_type};
 
 pub(crate) struct MqttShared {
     pub(super) cap: Cell<usize>,
-    pub(super) queues: RefCell<MqttSharedQueues>,
+    queues: RefCell<MqttSharedQueues>,
     pub(super) inflight_idx: Cell<u16>,
     pub(super) pool: Rc<MqttSinkPool>,
     pub(super) state: State,
@@ -52,6 +52,11 @@ impl MqttShared {
             }),
             inflight_idx: Cell::new(0),
         }
+    }
+
+    pub(super) fn with_queues<R>(&self, f: impl FnOnce(&mut MqttSharedQueues) -> R) -> R {
+        let mut queues = self.queues.borrow_mut();
+        f(&mut queues)
     }
 
     pub(super) fn has_credit(&self) -> bool {


### PR DESCRIPTION
Adds MqttShared::with_queues and hides queues from direct access.