### PR TITLE
Use default keepalive from `Connect` packet.

### DIFF
--- a/src/v3/handshake.rs
+++ b/src/v3/handshake.rs
@@ -41,7 +41,7 @@ impl<Io> Handshake<Io> {
         let Handshake { io, shared, pkt } = self;
         // [MQTT-3.1.2-24].
         let keepalive = if pkt.keep_alive != 0 {
-            (pkt.keep_alive << 2).checked_mul(3).unwrap_or(u16::MAX)
+            (pkt.keep_alive >> 1).checked_mul(3).unwrap_or(u16::MAX)
         } else {
             30
         };

--- a/src/v3/handshake.rs
+++ b/src/v3/handshake.rs
@@ -41,7 +41,7 @@ impl<Io> Handshake<Io> {
         let Handshake { io, shared, pkt } = self;
         // [MQTT-3.1.2-24].
         let keepalive = if pkt.keep_alive != 0 {
-            (pkt.keep_alive >> 1).checked_mul(3).unwrap_or(u16::MAX)
+            (pkt.keep_alive >> 1).checked_add(pkt.keep_alive).unwrap_or(u16::MAX)
         } else {
             30
         };

--- a/src/v5/handshake.rs
+++ b/src/v5/handshake.rs
@@ -63,7 +63,7 @@ impl<Io> Handshake<Io> {
         let Handshake { io, shared, pkt, .. } = self;
         // [MQTT-3.1.2-22]
         let keepalive = if pkt.keep_alive != 0 {
-            (pkt.keep_alive >> 1).checked_mul(3).unwrap_or(u16::MAX)
+            (pkt.keep_alive >> 1).checked_add(pkt.keep_alive).unwrap_or(u16::MAX)
         } else {
             30
         };

--- a/src/v5/handshake.rs
+++ b/src/v5/handshake.rs
@@ -60,14 +60,21 @@ impl<Io> Handshake<Io> {
             packet.receive_max = Some(NonZeroU16::new(self.max_receive).unwrap());
         }
 
+        let Handshake { io, shared, pkt, .. } = self;
+        // [MQTT-3.1.2-22]
+        let keepalive = if pkt.keep_alive != 0 {
+            (pkt.keep_alive << 2).checked_mul(3).unwrap_or(u16::MAX)
+        } else {
+            30
+        };
         HandshakeAck {
-            io: self.io,
-            shared: self.shared,
+            io,
+            shared,
             session: Some(st),
             lw: 256,
             read_hw: 4 * 1024,
             write_hw: 4 * 1024,
-            keepalive: 30,
+            keepalive,
             packet,
         }
     }

--- a/src/v5/handshake.rs
+++ b/src/v5/handshake.rs
@@ -63,7 +63,7 @@ impl<Io> Handshake<Io> {
         let Handshake { io, shared, pkt, .. } = self;
         // [MQTT-3.1.2-22]
         let keepalive = if pkt.keep_alive != 0 {
-            (pkt.keep_alive << 2).checked_mul(3).unwrap_or(u16::MAX)
+            (pkt.keep_alive >> 1).checked_mul(3).unwrap_or(u16::MAX)
         } else {
             30
         };


### PR DESCRIPTION
It would be great if by default `Handshake` can honor keep alive value from `Connect` packet. Application developers can always override it in their handshake handlers if needed.

Ref: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349238
> If the Keep Alive value is non-zero and the Server does not receive a Control Packet from the Client within one and a half times the Keep Alive time period, it MUST disconnect the Network Connection to the Client as if the network had failed [MQTT-3.1.2-24].