### PR TITLE
Change SharedSubsription to SharedSubscription

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## [0.8.4] - 2022-0x-xx
 
 * Add serializer and deserializer derive (#89)
-* Correct spelling of SubscribeAckReason::SharedSubsriptionNotSupported (#93)
+* Correct spelling of SubscribeAckReason::SharedSubsriptionNotSupported and DisconnectReasonCode::SharedSubsriptionNotSupported (#93)
 
 ## [0.8.3] - 2022-01-10
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## [0.8.4] - 2022-0x-xx
 
 * Add serializer and deserializer derive (#89)
+* Correct spelling of SubscribeAckReason::SharedSubsriptionNotSupported (#93)
 
 ## [0.8.3] - 2022-01-10
 

--- a/src/v5/codec/packet/disconnect.rs
+++ b/src/v5/codec/packet/disconnect.rs
@@ -43,7 +43,7 @@ prim_enum! {
         QosNotSupported = 155,
         UseAnotherServer = 156,
         ServerMoved = 157,
-        SharedSubsriptionNotSupported = 158,
+        SharedSubscriptionNotSupported = 158,
         ConnectionRateExceeded = 159,
         MaximumConnectTime = 160,
         SubscriptionIdentifiersNotSupported = 161,

--- a/src/v5/codec/packet/subscribe.rs
+++ b/src/v5/codec/packet/subscribe.rs
@@ -78,7 +78,7 @@ prim_enum! {
         TopicFilterInvalid = 143,
         PacketIdentifierInUse = 145,
         QuotaExceeded = 151,
-        SharedSubsriptionNotSupported = 158,
+        SharedSubscriptionNotSupported = 158,
         SubscriptionIdentifiersNotSupported = 161,
         WildcardSubscriptionsNotSupported = 162
     }


### PR DESCRIPTION
Corrects spelling of this enum.  Search finds no other instances of the prior enum value.

Addresses issue #93 