### PR TITLE
FIX #95: PubAckReason enum contains ReceiveMaximumExceeded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Add serializer and deserializer derive (#89)
 * Correct spelling of SubscribeAckReason::SharedSubsriptionNotSupported and DisconnectReasonCode::SharedSubsriptionNotSupported (#93)
+* Removed PubAckReason::ReceiveMaximumExceeded as this error code is only valid for DISCONNECT packets (#95)
 
 ## [0.8.3] - 2022-01-10
 

--- a/src/v5/codec/packet/pubacks.rs
+++ b/src/v5/codec/packet/pubacks.rs
@@ -38,7 +38,6 @@ prim_enum! {
         NotAuthorized = 135,
         TopicNameInvalid = 144,
         PacketIdentifierInUse = 145,
-        ReceiveMaximumExceeded = 147,
         QuotaExceeded = 151,
         PayloadFormatInvalid = 153
     }


### PR DESCRIPTION
Corrects #95 to remove the enum value PubAckReason::ReceiveMaximumExceeded as it is outside the MQTT5 specification.

Verified ``cargo build`` successfully completes.