### PR TITLE
FIX #97: subs.rs example should use confirm instead of subscribe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Add serializer and deserializer derive (#89)
 * Correct spelling of SubscribeAckReason::SharedSubsriptionNotSupported and DisconnectReasonCode::SharedSubsriptionNotSupported (#93)
 * Removed PubAckReason::ReceiveMaximumExceeded as this error code is only valid for DISCONNECT packets (#95)
+* Update subs.rs example to use confirm instead of subscribe (#97)
 
 ## [0.8.3] - 2022-01-10
 

--- a/examples/subs.rs
+++ b/examples/subs.rs
@@ -89,7 +89,7 @@ fn control_service_factory() -> impl ServiceFactory<
                 // store subscribed topics in session, publish service uses this list for echos
                 s.iter_mut().for_each(|mut s| {
                     session.subscriptions.borrow_mut().push(s.topic().clone());
-                    s.subscribe(v5::QoS::AtLeastOnce);
+                    s.confirm(v5::QoS::AtLeastOnce);
                 });
 
                 Ready::Ok(s.ack())


### PR DESCRIPTION
Fix #97 to use confirm instead of subscribe.  