### PR TITLE
v5: fix Topic Alias handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [0.9.2] - 2022-12-15
+
+* v5: fix topic alias handling
+
 ## [0.9.1] - 2022-11-17
 
 * v5: allow omitting properties length if it is 0 in packets without payload regardless of reason code or its presence.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntex-mqtt"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["ntex contributors <team@ntex.rs>"]
 description = "Client and Server framework for MQTT v5 and v3.1.1 protocols"
 documentation = "https://docs.rs/ntex-mqtt"

--- a/src/v5/client/dispatcher.rs
+++ b/src/v5/client/dispatcher.rs
@@ -171,7 +171,7 @@ where
                     // handle topic aliases
                     if let Some(alias) = publish.properties.topic_alias {
                         if publish.topic.is_empty() {
-                            // lookup topic by provided alias 
+                            // lookup topic by provided alias
                             match inner.aliases.get(&alias) {
                                 Some(aliased_topic) => publish.topic = aliased_topic.clone(),
                                 None => {

--- a/src/v5/client/dispatcher.rs
+++ b/src/v5/client/dispatcher.rs
@@ -4,7 +4,7 @@ use std::{future::Future, marker::PhantomData, num::NonZeroU16, pin::Pin, rc::Rc
 
 use ntex::io::DispatchItem;
 use ntex::service::Service;
-use ntex::util::{Either, HashSet, Ready};
+use ntex::util::{ByteString, Either, HashMap, HashSet, Ready};
 
 use crate::error::{MqttError, ProtocolError};
 use crate::types::packet_type;
@@ -53,7 +53,7 @@ struct Inner<C> {
 
 struct PublishInfo {
     inflight: HashSet<NonZeroU16>,
-    aliases: HashSet<NonZeroU16>,
+    aliases: HashMap<NonZeroU16, ByteString>,
 }
 
 impl<T, C, E> Dispatcher<T, C, E>
@@ -77,7 +77,7 @@ where
                 control,
                 sink,
                 info: RefCell::new(PublishInfo {
-                    aliases: HashSet::default(),
+                    aliases: HashMap::default(),
                     inflight: HashSet::default(),
                 }),
             }),
@@ -132,7 +132,7 @@ where
         log::trace!("Dispatch packet: {:#?}", request);
 
         match request {
-            DispatchItem::Item(codec::Packet::Publish(publish)) => {
+            DispatchItem::Item(codec::Packet::Publish(mut publish)) => {
                 let info = self.inner.clone();
                 let packet_id = publish.packet_id;
 
@@ -170,26 +170,45 @@ where
 
                     // handle topic aliases
                     if let Some(alias) = publish.properties.topic_alias {
-                        // check existing topic
                         if publish.topic.is_empty() {
-                            if !inner.aliases.contains(&alias) {
-                                return Either::Right(Either::Right(ControlResponse::new(
-                                    ControlMessage::proto_error(
-                                        ProtocolError::UnknownTopicAlias,
-                                    ),
-                                    &self.inner,
-                                )));
+                            // lookup topic by provided alias 
+                            match inner.aliases.get(&alias) {
+                                Some(aliased_topic) => publish.topic = aliased_topic.clone(),
+                                None => {
+                                    return Either::Right(Either::Right(ControlResponse::new(
+                                        ControlMessage::proto_error(
+                                            ProtocolError::UnknownTopicAlias,
+                                        ),
+                                        &self.inner,
+                                    )));
+                                }
                             }
                         } else {
-                            if alias.get() > self.max_topic_alias {
-                                return Either::Right(Either::Right(ControlResponse::new(
-                                    ControlMessage::proto_error(ProtocolError::MaxTopicAlias),
-                                    &self.inner,
-                                )));
-                            }
-
                             // record new alias
-                            inner.aliases.insert(alias);
+                            match inner.aliases.entry(alias) {
+                                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                                    if entry.get().as_str() != publish.topic.as_str() {
+                                        let mut topic = publish.topic.clone();
+                                        topic.trimdown();
+                                        entry.insert(topic);
+                                    }
+                                }
+                                std::collections::hash_map::Entry::Vacant(entry) => {
+                                    if alias.get() > self.max_topic_alias {
+                                        return Either::Right(Either::Right(
+                                            ControlResponse::new(
+                                                ControlMessage::proto_error(
+                                                    ProtocolError::MaxTopicAlias,
+                                                ),
+                                                &self.inner,
+                                            ),
+                                        ));
+                                    }
+                                    let mut topic = publish.topic.clone();
+                                    topic.trimdown();
+                                    entry.insert(topic);
+                                }
+                            }
                         }
                     }
                 }

--- a/src/v5/dispatcher.rs
+++ b/src/v5/dispatcher.rs
@@ -4,9 +4,11 @@ use std::{convert::TryFrom, future::Future, marker, num, pin::Pin, rc::Rc};
 
 use ntex::io::DispatchItem;
 use ntex::service::{fn_factory_with_config, Service, ServiceFactory};
+use ntex::util::ByteString;
 use ntex::util::{
     buffer::BufferService, inflight::InFlightService, join, Either, HashSet, Ready,
 };
+use ntex_util::HashMap;
 
 use crate::error::{MqttError, ProtocolError};
 
@@ -102,7 +104,7 @@ struct Inner<C> {
 
 struct PublishInfo {
     inflight: HashSet<num::NonZeroU16>,
-    aliases: HashSet<num::NonZeroU16>,
+    aliases: HashMap<num::NonZeroU16, ByteString>,
 }
 
 impl<T, C, E> Dispatcher<T, C, E>
@@ -131,7 +133,7 @@ where
                 control,
                 sink,
                 info: RefCell::new(PublishInfo {
-                    aliases: HashSet::default(),
+                    aliases: HashMap::default(),
                     inflight: HashSet::default(),
                 }),
             }),
@@ -187,7 +189,7 @@ where
         log::trace!("Dispatch v5 packet: {:#?}", request);
 
         match request {
-            DispatchItem::Item(codec::Packet::Publish(publish)) => {
+            DispatchItem::Item(codec::Packet::Publish(mut publish)) => {
                 let info = self.inner.clone();
                 let packet_id = publish.packet_id;
 
@@ -238,26 +240,45 @@ where
 
                     // handle topic aliases
                     if let Some(alias) = publish.properties.topic_alias {
-                        // check existing topic
                         if publish.topic.is_empty() {
-                            if !inner.aliases.contains(&alias) {
-                                return Either::Right(Either::Right(ControlResponse::new(
-                                    ControlMessage::proto_error(
-                                        ProtocolError::UnknownTopicAlias,
-                                    ),
-                                    &self.inner,
-                                )));
+                            // lookup topic by provided alias
+                            match inner.aliases.get(&alias) {
+                                Some(aliased_topic) => publish.topic = aliased_topic.clone(),
+                                None => {
+                                    return Either::Right(Either::Right(ControlResponse::new(
+                                        ControlMessage::proto_error(
+                                            ProtocolError::UnknownTopicAlias,
+                                        ),
+                                        &self.inner,
+                                    )));
+                                }
                             }
                         } else {
-                            if alias.get() > self.max_topic_alias {
-                                return Either::Right(Either::Right(ControlResponse::new(
-                                    ControlMessage::proto_error(ProtocolError::MaxTopicAlias),
-                                    &self.inner,
-                                )));
-                            }
-
                             // record new alias
-                            inner.aliases.insert(alias);
+                            match inner.aliases.entry(alias) {
+                                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                                    if entry.get().as_str() != publish.topic.as_str() {
+                                        let mut topic = publish.topic.clone();
+                                        topic.trimdown();
+                                        entry.insert(topic);
+                                    }
+                                }
+                                std::collections::hash_map::Entry::Vacant(entry) => {
+                                    if alias.get() > self.max_topic_alias {
+                                        return Either::Right(Either::Right(
+                                            ControlResponse::new(
+                                                ControlMessage::proto_error(
+                                                    ProtocolError::MaxTopicAlias,
+                                                ),
+                                                &self.inner,
+                                            ),
+                                        ));
+                                    }
+                                    let mut topic = publish.topic.clone();
+                                    topic.trimdown();
+                                    entry.insert(topic);
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Ensures that if topic is empty in PUBLISH and topic alias is set, topic will be set to value previously assigned to the alias.