### PR TITLE
Update KA timeout logic

### DIFF
--- a/tests/test_server_v5.rs
+++ b/tests/test_server_v5.rs
@@ -616,10 +616,19 @@ async fn test_keepalive2() {
     ntex::rt::spawn(client.start_default());
 
     assert!(sink.is_open());
+
     let res =
         sink.publish(ByteString::from_static("topic"), Bytes::new()).send_at_least_once().await;
     assert!(res.is_ok());
-    sleep(Duration::from_millis(500)).await;
+    sleep(Duration::from_millis(750)).await;
+    assert!(!ka.load(Relaxed));
+
+    let res =
+        sink.publish(ByteString::from_static("topic"), Bytes::new()).send_at_least_once().await;
+    assert!(res.is_ok());
+    sleep(Duration::from_millis(750)).await;
+    assert!(!ka.load(Relaxed));
+
     let res =
         sink.publish(ByteString::from_static("topic"), Bytes::new()).send_at_least_once().await;
     assert!(res.is_ok());


### PR DESCRIPTION
I hope I understood the changes (and intentions) of PR #160 correctly as I tried to update them to what I think fixes the issue.

Reading the PR I assume that you wanted to prevent starting another KA timer if one was already running. So I kept that logic but I renamed the `NO_KA_TIMEOUT` flag (to make it consistent with the use and purpose of the `READ_TIMEOUT` flag) and updated the logic just a little to make sure it does what is intended (hoping to simplify it just a little to make it easier to reason about, but I understand that can be personal).

If I run my test setup now I see that a new KA timer is started every time data was previously received and its now waiting for new data. Curious what you think of it and if you agree this might have been a bug (as before this change I only saw a new KA timer being started once when the program started).

Thanks,
Sander