### PR TITLE
Handle QoS 0 messages when the client disconnect

### DIFF
--- a/src/v3/dispatcher.rs
+++ b/src/v3/dispatcher.rs
@@ -217,7 +217,7 @@ where
                     )));
                 }
 
-                if inner.sink.is_closed() {
+                if inner.sink.is_closed() && publish.qos > QoS::AtMostOnce {
                     return Either::Right(Either::Left(Ready::Ok(None)));
                 }
 

--- a/src/v5/dispatcher.rs
+++ b/src/v5/dispatcher.rs
@@ -305,7 +305,7 @@ where
                         }
                     }
 
-                    if state.is_closed() {
+                    if state.is_closed() && publish.qos > codec::QoS::AtMostOnce {
                         return Either::Right(Either::Left(Ready::Ok(None)));
                     }
                 }

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -392,6 +392,7 @@ async fn test_handle_incoming_qos0() -> std::io::Result<()> {
         let publish = publish2.clone();
         let disconnect = disconnect2.clone();
         MqttServer::new(handshake)
+            .handle_qos_after_disconnect(true)
             .publish(move |_| {
                 publish.store(true, Relaxed);
                 async {

--- a/tests/test_server_v5.rs
+++ b/tests/test_server_v5.rs
@@ -1011,6 +1011,7 @@ async fn test_handle_incoming_qos0() -> std::io::Result<()> {
         let publish = publish2.clone();
         let disconnect = disconnect2.clone();
         MqttServer::new(handshake)
+            .handle_qos_after_disconnect(true)
             .publish(move |p: Publish| {
                 publish.store(true, Relaxed);
                 Ready::Ok::<_, TestError>(p.ack())


### PR DESCRIPTION
The issue described in #51 still exists.

My solution is dispatching the received PUBLISH messages if the QoS is 0 no matter whether the client is disconnected or not.