### PR TITLE
Derive Hash for the QoS enum

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -8,7 +8,7 @@ pub(crate) const MAX_PACKET_SIZE: u32 = 0xF_FF_FF_FF;
 
 prim_enum! {
     /// Quality of Service
-    #[derive(serde::Serialize, serde::Deserialize, PartialOrd, Ord)]
+    #[derive(serde::Serialize, serde::Deserialize, PartialOrd, Ord, Hash)]
     pub enum QoS {
         /// At most once delivery
         ///


### PR DESCRIPTION
We would like to be able to use the QoS as part of a HashMap key (e.g. `HashMap<((String, QoS), ...>`), but for that `QoS` needs to implement the `Hash` trait.